### PR TITLE
update django utils models to be django 2.0 compatible

### DIFF
--- a/oauth2client/contrib/django_util/models.py
+++ b/oauth2client/contrib/django_util/models.py
@@ -51,10 +51,10 @@ class CredentialsField(models.Field):
         else:
             try:
                 return jsonpickle.decode(
-                    base64.b64decode(encoding.smart_bytes(value)).decode())
+                    base64.b64decode(encoding.smart_bytes(value)).decode()
+                )
             except ValueError:
-                return pickle.loads(
-                    base64.b64decode(encoding.smart_bytes(value)))
+                return pickle.loads(base64.b64decode(encoding.smart_bytes(value)))
 
     def get_prep_value(self, value):
         """Overrides ``models.Field`` method. This is used to convert
@@ -65,7 +65,8 @@ class CredentialsField(models.Field):
             return None
         else:
             return encoding.smart_text(
-                base64.b64encode(jsonpickle.encode(value).encode()))
+                base64.b64encode(jsonpickle.encode(value).encode())
+            )
 
     def value_to_string(self, obj):
         """Convert the field value from the provided model to a string.
@@ -78,5 +79,5 @@ class CredentialsField(models.Field):
         Returns:
             string, the serialized field value
         """
-        value = self._get_val_from_obj(obj)
+        value = self.value_from_object(obj)
         return self.get_prep_value(value)


### PR DESCRIPTION
**Note**: oauth2client is now deprecated. As such, it is unlikely that we will
review or merge to your pull request. We recommend you use
[google-auth](https://google-auth.readthedocs.io) and [oauthlib](http://oauthlib.readthedocs.io/).
