### PR TITLE
bump version to 4.1.5

### DIFF
--- a/oauth2client/__init__.py
+++ b/oauth2client/__init__.py
@@ -14,11 +14,10 @@
 
 """Client library for using OAuth2, especially with Google APIs."""
 
-__version__ = '4.1.4'
+__version__ = '4.1.5'
 
 GOOGLE_AUTH_URI = 'https://accounts.google.com/o/oauth2/v2/auth'
 GOOGLE_DEVICE_URI = 'https://oauth2.googleapis.com/device/code'
 GOOGLE_REVOKE_URI = 'https://oauth2.googleapis.com/revoke'
 GOOGLE_TOKEN_URI = 'https://oauth2.googleapis.com/token'
 GOOGLE_TOKEN_INFO_URI = 'https://oauth2.googleapis.com/tokeninfo'
-


### PR DESCRIPTION
**Note**: oauth2client is now deprecated. As such, it is unlikely that we will
review or merge to your pull request. We recommend you use
[google-auth](https://google-auth.readthedocs.io) and [oauthlib](http://oauthlib.readthedocs.io/).
